### PR TITLE
Only set the payload without overriding the whole msg

### DIFF
--- a/nodes/device_manager.html
+++ b/nodes/device_manager.html
@@ -255,7 +255,7 @@ limitations under the License.
 </script>
 
 <script type="text/x-red" data-help-name="device-manager">
-    <p>Device manager node lets you perform actions on devices that are connected to IBM Watson IoT Platform. For some fields, the value can be passed in the msg. Any fields set on the node explicitly take precedence.</p>
+    <p>PhG-Device manager node lets you perform actions on devices that are connected to IBM Watson IoT Platform. For some fields, the value can be passed in the msg. Any fields set on the node explicitly take precedence.</p>
     <p>
     <dl>
     <dt>Authentication</dt>

--- a/nodes/device_manager.js
+++ b/nodes/device_manager.js
@@ -117,18 +117,20 @@ module.exports = function(RED) {
           }
 
           var onSuccess = function(argument) {
-                  var msg = {
-                    payload : argument
-                  }
+                  //var msg = {
+                  //  payload : argument
+                  //}
+		  msg.payload=argument;
                   node.send(msg);
                   node.status({fill:"green",shape:"dot",text:"Success"});
                   clearStatus();
           };
 
           var onError =  function(argument) {
-                  var msg = {
-                    payload : argument
-                  }
+                  //var msg = {
+                  //  payload : argument
+                  //}
+		  msg.payload=argument;
                   node.send(msg);
 
                   node.status({fill:"red",shape:"dot",text:"Error. Refer to debug tab"});

--- a/nodes/device_type_manager.html
+++ b/nodes/device_type_manager.html
@@ -395,7 +395,7 @@ limitations under the License.
 
 
 <script type="text/x-red" data-help-name="device-type-manager">
-    <p>Device Type Manager node can perform actions on device types in the IBM Watson IoT Platform. For some fields, the value can be passed in the <code>msg</code>. Any fields set on the node explicitly take precedence.</p>
+    <p>PhG-Device Type Manager node can perform actions on device types in the IBM Watson IoT Platform. For some fields, the value can be passed in the <code>msg</code>. Any fields set on the node explicitly take precedence.</p>
     <p>
     <dl>
 

--- a/nodes/device_type_manager.js
+++ b/nodes/device_type_manager.js
@@ -116,23 +116,24 @@ module.exports = function(RED) {
           }
 
           var onSuccess = function(argument) {
-                  var msg = {
-                    payload : argument
-                  }
+                  //var msg = {
+                  //  payload : argument
+                  //}
+		  msg.payload = argument;
                   node.send(msg);
                   node.status({fill:"green",shape:"dot",text:"Sucess"});
                   clearStatus();
           };
 
           var onError =  function(argument) {
-                  var msg = {
-                    payload : argument
-                  }
+                  //var msg = {
+                  //  payload : argument
+                  //}
+		  msg.payload = argument;
                   node.send(msg);
 
                   node.status({fill:"red",shape:"dot",text:"Error. Refer to debug tab"});
           };
-
 
           node.status({fill:"blue",shape:"dot",text:"Requesting"});
 
@@ -257,8 +258,6 @@ module.exports = function(RED) {
           }
         });
     }
-
-
 
 	RED.nodes.registerType("device-type-manager",DeviceTypeHandler);
 	// RED.nodes.registerType("wiotptype",WIoTPNode, {


### PR DESCRIPTION
Fix for issue #6, only set the payload without overriding the whole msg and context.
I validated on a Node-RED flow that this fix allows to build a HTTP requests that lists the devices for example, which was not possible before the fix.
